### PR TITLE
Development

### DIFF
--- a/app/Http/Requests/Api/V1/Department/ProgramProposalWizardRequest.php
+++ b/app/Http/Requests/Api/V1/Department/ProgramProposalWizardRequest.php
@@ -51,7 +51,7 @@ class ProgramProposalWizardRequest extends FormRequest
             'peos.*.statement' => [
                 'required',
                 'string',
-                'max:100',
+
             ],
 
             // PEO to Mission


### PR DESCRIPTION
This pull request includes a minor update to the validation rules in the `ProgramProposalWizardRequest` class. The change removes the maximum character limit (`max:100`) for the `peos.*.statement` field.

* [`app/Http/Requests/Api/V1/Department/ProgramProposalWizardRequest.php`](diffhunk://#diff-1d7c2402681f8dc7b26d82c0ef702f541b304be2e1a13f0480af0d1de0b10033L54-R54): Removed the `max:100` validation rule for the `peos.*.statement` field in the `rules` method.