### PR TITLE
Api/department/curriculum

### DIFF
--- a/app/Http/Controllers/Api/V1/Department/DepartmentRevisionController.php
+++ b/app/Http/Controllers/Api/V1/Department/DepartmentRevisionController.php
@@ -428,7 +428,8 @@ class DepartmentRevisionController extends Controller
 
             // Now make the proposal pending again
             $programProposal->update([
-                'status' => 'pending'
+                'status' => 'pending',
+                'department_revision_required' => false
             ]);
 
             DB::commit();

--- a/app/Http/Controllers/Api/V1/Department/ProgramOutcomeController.php
+++ b/app/Http/Controllers/Api/V1/Department/ProgramOutcomeController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\Api\V1\Department\ProgramOutcomeRequest;
 use App\Http\Resources\Api\V1\Department\ProgramOutcomeResource;
 use App\Models\ProgramOutcome;
 use Exception;
+use Illuminate\Http\Request;
 
 class ProgramOutcomeController extends Controller
 {
@@ -19,10 +20,17 @@ class ProgramOutcomeController extends Controller
         $this->middleware('role:Department');
     }
 
-    public function index()
+    public function index(Request $request)
     {
         try {
-            $pos = ProgramOutcome::with('program')->get();
+            $query = ProgramOutcome::with('programProposal');
+            // $pos = ProgramOutcome::all();
+
+            if ($request->has('program_proposal_id')) {
+                $query->where('program_proposal_id', $request->program_proposal_id);
+            }
+
+            $pos = $query->get();
 
             return ProgramOutcomeResource::collection($pos)->additional([
                 'message' => 'POS retrieved successfully'

--- a/app/Http/Controllers/Api/V1/Department/ProgramProposalController.php
+++ b/app/Http/Controllers/Api/V1/Department/ProgramProposalController.php
@@ -295,7 +295,7 @@ class ProgramProposalController extends Controller
 
             // Update proposal status if all courses are completed
             if ($allCoursesCompleted && $totalAssignedCourses > 0) {
-                // Only update if current status is 'pending'
+                // Only update if current status is 'pending' or 'revision
                 if ($programProposal->status === 'pending' || $programProposal->status === 'revision') {
                     $programProposal->update([
                         'status' => 'review'

--- a/app/Http/Controllers/Api/V1/Department/ProgramProposalController.php
+++ b/app/Http/Controllers/Api/V1/Department/ProgramProposalController.php
@@ -296,7 +296,7 @@ class ProgramProposalController extends Controller
             // Update proposal status if all courses are completed
             if ($allCoursesCompleted && $totalAssignedCourses > 0) {
                 // Only update if current status is 'pending'
-                if ($programProposal->status === 'pending') {
+                if ($programProposal->status === 'pending' || $programProposal->status === 'revision') {
                     $programProposal->update([
                         'status' => 'review'
                     ]);
@@ -307,7 +307,7 @@ class ProgramProposalController extends Controller
                     ]);
                 } else {
                     return response()->json([
-                        'message' => 'All courses are completed, but proposal status cannot be updated because it is not in pending state',
+                        'message' => 'All courses are completed, but proposal status cannot be updated because it is not in pending or revision state',
 
                     ]);
                 }

--- a/app/Http/Controllers/Api/V1/Shared/FetchBothLevelRevisionController.php
+++ b/app/Http/Controllers/Api/V1/Shared/FetchBothLevelRevisionController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Shared;
+
+use App\Http\Controllers\Controller;
+use App\Models\ProgramProposal;
+use App\Models\ProgramProposalRevision;
+use App\Models\CurriculumCourse;
+use Exception;
+
+class FetchBothLevelRevisionController extends Controller
+{
+    //
+    public function __construct()
+    {
+        $this->middleware('role:Dean');
+        $this->middleware('auth:sanctum');
+    }
+
+    public function fetchRevisions(ProgramProposal $programProposal)
+    {
+        try {
+            // Get the latest version number for this proposal
+            $latestVersion = ProgramProposalRevision::where('program_proposal_id', $programProposal->id)
+                ->max('version');
+
+            if (!$latestVersion) {
+                return response()->json([
+                    'message' => 'No revisions found for this proposal.'
+                ], 404);
+            }
+
+            // Fetch all department-level revisions at the latest version
+            $departmentRevisions = ProgramProposalRevision::where('program_proposal_id', $programProposal->id)
+                ->where('level', 'department')
+                ->where('version', $latestVersion)
+                ->get(['id', 'section', 'details', 'created_at', 'version']);
+
+            // Fetch all committee-level revisions at the latest version
+            $committeeRevisions = ProgramProposalRevision::where('program_proposal_id', $programProposal->id)
+                ->where('level', 'committee')
+                ->where('version', $latestVersion)
+                ->with(['curriculumCourse' => function ($query) {
+                    $query->with('course:id,code,descriptive_title');
+                }])
+                ->get(['id', 'curriculum_course_id', 'section', 'details', 'created_at', 'version']);
+
+            // Group committee revisions by curriculum course for better organization
+            $groupedCommitteeRevisions = $committeeRevisions->groupBy('curriculum_course_id')
+                ->map(function ($revisions) {
+                    $curriculumCourse = $revisions->first()->curriculumCourse;
+                    $course = $curriculumCourse->course;
+
+                    return [
+                        'curriculum_course_id' => $curriculumCourse->id,
+                        'course_code' => $course ? $course->code : 'N/A',
+                        'course_title' => $course ? $course->descriptive_title : 'N/A',
+                        'revisions' => $revisions->map(function ($revision) {
+                            return [
+                                'id' => $revision->id,
+                                'section' => $revision->section,
+                                'details' => $revision->details,
+                                'created_at' => $revision->created_at
+                            ];
+                        })
+                    ];
+                })->values();
+
+            return response()->json([
+                'program_proposal_id' => $programProposal->id,
+                'version' => $latestVersion,
+                'department_revisions' => $departmentRevisions,
+                'committee_revisions' => $groupedCommitteeRevisions,
+                'message' => 'All revisions fetched successfully.'
+            ], 200);
+        } catch (Exception $e) {
+            return response()->json([
+                'message' => 'Failed to retrieve revisions',
+                'error' => $e->getMessage()
+            ], 500);
+        }
+    }
+}

--- a/app/Http/Requests/Api/V1/Dean/ProposalReviewRequest.php
+++ b/app/Http/Requests/Api/V1/Dean/ProposalReviewRequest.php
@@ -26,7 +26,7 @@ class ProposalReviewRequest extends FormRequest
             $rules['department_level.*.details'] = 'required|string';
 
             $rules['committee_level.*.curriculum_course_id'] = 'required|exists:curriculum_courses,id';
-            $rules['committee_level.*.section'] = 'required|string|in:course_outcomes,abcd,cpa,po_mappings,tla_tasks,tla_assessment_methods';
+            $rules['committee_level.*.section'] = 'required|string|in:course_outcomes,abcd,cpa,po_mappings,tla_tasks,tla_assessment_method';
             $rules['committee_level.*.details'] = 'required|string';
         }
 

--- a/app/Http/Resources/Api/V1/Department/ProgramOutcomeResource.php
+++ b/app/Http/Resources/Api/V1/Department/ProgramOutcomeResource.php
@@ -26,8 +26,8 @@ class ProgramOutcomeResource extends JsonResource
             }),
             'name' => $this->name,
             'statement' => $this->statement,
-            'created_at' => $this->created_at,
-            'updated_at' => $this->updated_at,
+            // 'created_at' => $this->created_at,
+            // 'updated_at' => $this->updated_at,
         ];
     }
 }

--- a/app/Http/Resources/Api/V1/Department/ProgramProposalResource.php
+++ b/app/Http/Resources/Api/V1/Department/ProgramProposalResource.php
@@ -49,6 +49,7 @@ class ProgramProposalResource extends JsonResource
             'version' => $this->version,
             'department_revision_required' => $this->department_revision_required,
             'committee_revision_required' => $this->committee_revision_required,
+            'has_revision_record' => $this->revisions()->exists(),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
 

--- a/app/Http/Resources/Api/V1/Department/ProgramProposalResource.php
+++ b/app/Http/Resources/Api/V1/Department/ProgramProposalResource.php
@@ -47,6 +47,8 @@ class ProgramProposalResource extends JsonResource
             'status' => $this->status,
             'comment' => $this->comment,
             'version' => $this->version,
+            'department_revision_required' => $this->department_revision_required,
+            'committee_revision_required' => $this->committee_revision_required,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
 

--- a/routes/api/v1/role.php
+++ b/routes/api/v1/role.php
@@ -28,6 +28,7 @@ use App\Http\Controllers\Api\V1\Faculty\CommitteeRevisionController;
 use App\Http\Controllers\Api\V1\Faculty\CourseDetailsWizardController;
 use App\Http\Controllers\Api\V1\Faculty\FetchCommitteeRevisionController;
 use App\Http\Controllers\Api\V1\Shared\CurriculumCoursePOController;
+use App\Http\Controllers\Api\V1\Shared\FetchBothLevelRevisionController;
 use App\Http\Controllers\Api\V1\Shared\ProgramProposalRevisionController;
 use Illuminate\Support\Facades\Route;
 
@@ -69,6 +70,8 @@ Route::middleware(['role:Dean'])->prefix('dean')->group(function () {
   Route::apiResource('program-proposals', ProgramProposalController::class);
   Route::apiResource('curriculum-courses', CurriculumCourseController::class);
   Route::post('/program-proposals/{programProposal}/review', [ProposalReviewController::class, 'review']);
+
+  Route::get('/program-proposals/{program_proposal}/revisions', [FetchBothLevelRevisionController::class, 'fetchRevisions']);
 });
 
 


### PR DESCRIPTION
This pull request introduces several changes across multiple files to enhance functionality related to program proposals, revisions, and program outcomes. Key updates include adding a new controller for fetching revisions at both department and committee levels, improving the handling of proposal statuses, and refining request and resource classes.

### Enhancements to Revision and Proposal Management:
* **New `FetchBothLevelRevisionController`**: Added a controller to fetch both department-level and committee-level revisions for a program proposal, including grouping committee revisions by curriculum course for better organization.
* **Proposal Status Updates**:
  - Updated `checkReadyForReview` in `ProgramProposalController` to allow status changes from "revision" to "review" in addition to "pending".
  - Adjusted the error message to reflect the new status conditions.

### Improvements to Program Outcome Handling:
* **Filtering Program Outcomes**: Modified the `index` method in `ProgramOutcomeController` to support filtering by `program_proposal_id`.
* **Resource Updates**:
  - Added fields (`department_revision_required`, `committee_revision_required`, `has_revision_record`) to `ProgramProposalResource`.
  - Removed `created_at` and `updated_at` fields from `ProgramOutcomeResource`.

### Validation and Routing Adjustments:
* **Validation Rule Update**: Corrected the `section` validation rule in `ProposalReviewRequest` to fix a typo (`tla_assessment_method` instead of `tla_assessment_methods`).
* **New API Route**: Added a route to fetch revisions for a specific program proposal using the new `FetchBothLevelRevisionController`.