### PR TITLE
Refactor DepartmentController to restrict department visibility for D…

### DIFF
--- a/app/Http/Controllers/Api/V1/Admin/DepartmentController.php
+++ b/app/Http/Controllers/Api/V1/Admin/DepartmentController.php
@@ -18,18 +18,24 @@ class DepartmentController extends Controller
     public function __construct()
     {
         $this->middleware('auth:sanctum');
-        $this->middleware('role:Admin');
+        $this->middleware('role:Admin,Dean');
     }
     public function index()
     {
         try {
-            // $departments = Department::all();
-            $departments = Department::with('program')->get();
+            $user = auth()->user();
+            $query = Department::query()->with('program');
+
+            // If user is a Dean, only show departments from their faculty
+            if ($user->role->name === 'Dean') {
+                $query->where('faculty_id', $user->faculty_id);
+            }
+
+            $departments = $query->get();
 
             return response()->json([
                 'data' => DepartmentResource::collection($departments),
                 'message' => 'Departments retrieved successfully',
-
             ]);
         } catch (Exception $e) {
             return response()->json([

--- a/routes/api/v1/role.php
+++ b/routes/api/v1/role.php
@@ -70,6 +70,7 @@ Route::middleware(['role:Dean'])->prefix('dean')->group(function () {
   Route::apiResource('program-proposals', ProgramProposalController::class);
   Route::apiResource('curriculum-courses', CurriculumCourseController::class);
   Route::post('/program-proposals/{programProposal}/review', [ProposalReviewController::class, 'review']);
+  Route::apiResource('departments', DepartmentController::class)->except('store', 'update', 'destroy');
 
   Route::get('/program-proposals/{program_proposal}/revisions', [FetchBothLevelRevisionController::class, 'fetchRevisions']);
 });


### PR DESCRIPTION
This pull request introduces changes to enhance role-based access control and refine the API routes for the `DepartmentController`. The key updates include allowing Deans to access department data specific to their faculty and adding a new API resource route for departments.

### Role-based access control improvements:
* Updated the middleware in `DepartmentController` to allow both Admin and Dean roles to access department-related endpoints. Additionally, modified the `index` method to restrict Deans to viewing only departments within their faculty by applying a conditional query based on the authenticated user's role and faculty ID. (`app/Http/Controllers/Api/V1/Admin/DepartmentController.php`, [app/Http/Controllers/Api/V1/Admin/DepartmentController.phpL21-L32](diffhunk://#diff-181a5e1f9a5cdf172dd42d8fb30d6b8a8ea8d9b60b02a7905de9e0c563417242L21-L32))

### API route updates:
* Added a new `apiResource` route for departments in `routes/api/v1/role.php`, excluding the `store`, `update`, and `destroy` methods to ensure read-only access. (`routes/api/v1/role.php`, [routes/api/v1/role.phpR73](diffhunk://#diff-16600b05469a03a2962d4bf1f27db96016c5c0f0fa256799c94a8677c2f320efR73))…ean role and update role routes